### PR TITLE
Feature, KAN-65, KAN-62: Implement company social status API and refactor Twitter publis…

### DIFF
--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CompaniesController < ApplicationController
+      before_action :authenticate_user!, only: [:social_network_status] # Protect only this endpoint
+
+      # GET /api/v1/me/company_social_status
+      def social_network_status
+        user = current_user
+        unless user.team && user.team.company
+          render json: error_response(['User is not associated with a company.']), status: :not_found
+          return
+        end
+
+        company = user.team.company
+        credentials = company.credentials_twitter
+        has_twitter_creds = credentials&.has_credentials? || false
+
+        render json: success_response(
+          social_networks: {
+            twitter: {
+              has_credentials: has_twitter_creds
+            }
+            # Placeholder for other social networks if any
+            # e.g. facebook: { has_credentials: company.credentials_facebook&.has_credentials? || false }
+          }
+        ), status: :ok
+      end
+
+      # GET /api/v1/companies/:id
+      def show
+        company = Company.find_by(id: params[:id])
+        if company
+          # Select only safe attributes to expose
+          render json: success_response(company: company.as_json(only: [:id, :name])), status: :ok
+        else
+          render json: error_response(['Company not found.']), status: :not_found
+        end
+      end
+
+      private
+
+      # Assuming these are not yet in ApplicationController for this subtask's scope.
+      # If they are, these local definitions can be removed.
+      def success_response(resource)
+        { status: { code: 200, message: I18n.t('responses.success', default: 'Success') } }.merge(resource)
+      end
+
+      def error_response(errors_array)
+        { status: { code: 422, message: I18n.t('responses.error', default: 'Error') }, errors: errors_array }
+      end
+    end
+  end
+end

--- a/app/helpers/api/v1/publish_social_network/twitter/publish_helper.rb
+++ b/app/helpers/api/v1/publish_social_network/twitter/publish_helper.rb
@@ -12,51 +12,80 @@ module Api
       module Twitter
         # Post helper
         module PublishHelper
-          def self.twitter_client
-            @twitter_client ||= X::Client.new(
-              api_key: ENV.fetch('TWITTER_API_KEY', nil),
-              api_key_secret: ENV.fetch('TWITTER_API_KEY_SECRET', nil),
-              access_token: ENV.fetch('TWITTER_ACCESS_TOKEN', nil),
-              access_token_secret: ENV.fetch('TWITTER_ACCESS_TOKEN_SECRET', nil)
+          def self.twitter_client(api_key:, api_key_secret:, access_token:, access_token_secret:)
+            X::Client.new(
+              api_key: api_key,
+              api_key_secret: api_key_secret,
+              access_token: access_token,
+              access_token_secret: access_token_secret
             )
           end
 
           def self.post(post_id)
-            post = Post.find(post_id)
-            return if post.blank?
+            post_record = Post.find_by(id: post_id) # Renamed to avoid conflict
+            return unless post_record
 
-            st.update!(status: :in_progress_posting)
-            st = post.strategy
-            publish_tweet(post)
+            strategy = post_record.strategy # Define strategy for use throughout
+            strategy.update!(status: :in_progress_posting)
+
+            company = post_record.team&.company
+            unless company
+              strategy.update!(status: :failed)
+              Rails.logger.error "Twitter post failed: Post id #{post_id} has no associated company."
+              return
+            end
+
+            twitter_credentials = company.credentials_twitter
+            unless twitter_credentials&.has_credentials?
+              strategy.update!(status: :failed) # Or a more specific status like :missing_credentials
+              Rails.logger.error "Twitter post failed: Company #{company.id} missing Twitter credentials for Post id #{post_id}."
+              return
+            end
+
+            # Initialize client with credentials from DB
+            client = twitter_client(
+              api_key: twitter_credentials.api_key,
+              api_key_secret: twitter_credentials.api_key_secret,
+              access_token: twitter_credentials.access_token,
+              access_token_secret: twitter_credentials.access_token_secret
+            )
+
+            publish_tweet(post_record, client, strategy) # Pass client and strategy
+          rescue ActiveRecord::RecordNotFound
+            Rails.logger.error "Twitter post failed: Post id #{post_id} not found."
+            # No strategy to update if post not found. If strategy needs update, it must be found differently.
           rescue StandardError => e
-            st.update!(status: :failed)
+            # Ensure strategy is defined or handle nil; strategy might be nil if Post.find_by failed before strategy was set
+            defined?(strategy) && strategy&.update!(status: :failed)
             Rails.logger.error "Twitter post failed: #{e.message} - Post id #{post_id}"
           end
 
-          def self.publish_tweet(post)
+          def self.publish_tweet(post, client, strategy) # Added client and strategy as params
             Tempfile.create(['media', '.jpg']) do |tempfile|
               tempfile.binmode
               tempfile.write URI.open(post.image_url).read
               tempfile.rewind
 
               media_category = 'tweet_image'
-              media = X::MediaUploader.upload(client: twitter_client, file_path: tempfile.path, media_category:)
+              # Pass the initialized client here
+              media = X::MediaUploader.upload(client: client, file_path: tempfile.path, media_category: media_category)
 
               tweet_body = { text: post.description,
                              media: { media_ids: [media['media_id_string']] } }
-              tweet = twitter_client.post('tweets', tweet_body.to_json)
+              # Use the initialized client here
+              tweet = client.post('tweets', tweet_body.to_json)
 
-              st.update!(status: :posted)
+              strategy.update!(status: :posted) # Use passed strategy
               Rails.logger.info "Tweet posted successfully with data: #{tweet['data']['id']}"
             end
           rescue OpenURI::HTTPError => e
-            st.update!(status: :failed)
+            strategy.update!(status: :failed) # Use passed strategy
             Rails.logger.error "Failed to download the image: #{e.message}"
           rescue X::Error => e
-            st.update!(status: :failed_social_network)
+            strategy.update!(status: :failed_social_network) # Use passed strategy
             Rails.logger.error "X API Error: #{e.message}"
           rescue StandardError => e
-            st.update!(status: :failed_system)
+            strategy.update!(status: :failed_system) # Use passed strategy
             Rails.logger.error "An unexpected error occurred: #{e.message}"
           end
         end

--- a/app/models/credentials/twitter.rb
+++ b/app/models/credentials/twitter.rb
@@ -28,14 +28,7 @@ class Credentials::Twitter < ApplicationRecord
   encrypts :access_token
   encrypts :access_token_secret
 
-  after_initialize :set_defaults, if: :new_record?
-
-  private
-
-  def set_defaults
-    self.api_key ||= ENV.fetch('TWITTER_API_KEY', nil)
-    self.api_key_secret ||= ENV.fetch('TWITTER_API_KEY_SECRET', nil)
-    self.access_token ||= ENV.fetch('TWITTER_ACCESS_TOKEN', nil)
-    self.access_token_secret ||= ENV.fetch('TWITTER_ACCESS_TOKEN_SECRET', nil)
+  def has_credentials?
+    api_key.present? && api_key_secret.present? && access_token.present? && access_token_secret.present?
   end
 end

--- a/app/sidekiq/publish_social_network_post_job.rb
+++ b/app/sidekiq/publish_social_network_post_job.rb
@@ -4,26 +4,47 @@
 class PublishSocialNetworkPostJob
   include Sidekiq::Worker
 
-  def perform(args)
+  def perform(args) # Reverted to args
     Rails.logger.info 'Start Proccess Publish Post'
-    Rails.logger.info "ARGS publish post: #{args}"
+    Rails.logger.info "ARGS publish post: #{args}" # Log the whole hash
 
-    st = Post.find(post_id).strategy
+    post_id = args['post_id'] # Extract post_id from args
+    unless post_id
+      Rails.logger.error "Job arguments do not contain 'post_id'. Args: #{args}"
+      return
+    end
+
+    post_record = Post.find(post_id)
+    st = post_record.strategy # strategy can be nil if post has no strategy
+
+    # Proceed only if strategy is found
+    unless st
+      Rails.logger.error "No strategy found for Post id #{post_id}. Aborting publish."
+      return
+    end
+
     st.update!(status: :in_progress_config)
 
-    platform = 'twitter'
+    platform = 'twitter' # Assuming platform might be dynamic in future
     case platform
     when 'twitter'
-      Api::V1::PublishSocialNetwork::Twitter::PublishHelper.post(args['post_id'])
+      Api::V1::PublishSocialNetwork::Twitter::PublishHelper.post(post_id) # Pass post_id
     when 'tiktok'
       # TikTokHelper.post(description)
     else
       st.update!(status: :failed)
-      Rails.logger.error "Unsupported platform: #{platform} - user - #{args['creator_id']}"
+      Rails.logger.error "Unsupported platform: #{platform} - Post id #{post_id}"
     end
 
     Rails.logger.info 'Strategy processed successfully.'
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "Post not found: #{e.message} - Post id #{args['post_id']}" # Use args['post_id'] for logging consistency
+    # No strategy to update if post itself isn't found
   rescue StandardError => e
-    Rails.logger.error "Error processing strategy: #{e.message}"
+    # Log with post_id from args for context
+    # Ensure st is loaded before trying to update it, or it might be nil if Post.find failed earlier than RecordNotFound
+    loaded_strategy = defined?(st) ? st : nil
+    loaded_strategy&.update!(status: :failed)
+    Rails.logger.error "Error processing strategy: #{e.message} - Post id #{args['post_id']}"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get 'up' => 'rails/health#show', as: :rails_health_check
   namespace :api do
     namespace :v1 do
+      get '/me/company_social_status', to: 'companies#social_network_status'
+      resources :companies, only: [:show] # Provides GET /api/v1/companies/:id
       resources :posts, controller: 'posts/posts', only: %i[index show create update destroy]
       post '/strategy/create', to: 'strategies#create'
 

--- a/spec/requests/api/v1/companies_spec.rb
+++ b/spec/requests/api/v1/companies_spec.rb
@@ -1,0 +1,219 @@
+require 'swagger_helper' # Ensures Rswag DSL is available
+
+RSpec.describe 'Api::V1::CompaniesController', type: :request do
+  let!(:user) { create(:user) }
+  let!(:company) { create(:company) }
+  let!(:team) { create(:team, company: company) }
+  let!(:team_member) { create(:team_member, user: user, team: team) }
+
+  # --- Swagger Docs for GET /api/v1/me/company_social_status ---
+  path '/me/company_social_status' do # Removed /api/v1 prefix
+    get 'Retrieves social network credential status for the current user\'s company' do
+      tags 'Companies', 'User Profile'
+      produces 'application/json'
+      security [Bearer: []]
+
+      response '200', 'Social network status retrieved' do
+        schema type: :object,
+               properties: {
+                 status: { '$ref' => '#/components/schemas/StatusSuccess' },
+                 social_networks: {
+                   type: :object,
+                   properties: {
+                     twitter: {
+                       type: :object,
+                       properties: {
+                         has_credentials: { type: :boolean, example: true }
+                       },
+                       required: ['has_credentials']
+                     }
+                   },
+                   required: ['twitter']
+                 }
+               },
+               required: ['status', 'social_networks']
+
+        # This let! will cover the case for "complete Twitter credentials"
+        let!(:twitter_credentials) { create(:credentials_twitter, company: company, api_key: 'key', api_key_secret: 'secret', access_token: 'token', access_token_secret: 'token_secret') }
+        let(:Authorization) { "Bearer #{generate_jwt_token_for_user(user)}" }
+
+        run_test! do |response|
+          json_response = JSON.parse(response.body)
+          expect(json_response['status']['code']).to eq(200)
+          expect(json_response['social_networks']['twitter']['has_credentials']).to be_truthy
+        end
+      end
+
+      # Test for incomplete credentials (will be a separate RSpec context if not using run_test! for all variations)
+      # For Rswag, often one "happy path" `run_test!` is shown, others are standard RSpec examples.
+      # Or, create separate `response` blocks for different data setups if schema/examples change.
+      # The prompt implies integrating existing tests.
+      # This response block is for documentation of the 200 OK state.
+      # Specific data variations (incomplete creds, no creds) will be tested by existing RSpec examples.
+
+      response '401', 'Unauthorized' do
+        schema '$ref' => '#/components/schemas/StatusUnauthorized'
+        let(:Authorization) { "Bearer invalid_token" } # For Rswag sample
+        # This RSpec example covers the unauthenticated case
+        it 'returns status 401 (unauthorized)' do
+          # No Authorization header implicitly for this specific 'it' block
+          get '/api/v1/me/company_social_status' # No header for this specific example
+          expect(response).to have_http_status(:unauthorized)
+        end
+        # run_test! # Not ideal here if the `it` block above is the actual test
+      end
+
+      response '404', 'User not associated with a company' do
+        schema '$ref' => '#/components/schemas/StatusError' # Assuming a generic error schema or not_found
+        let(:user_no_company_for_doc) {
+          u = create(:user, username: "user_no_co_#{SecureRandom.hex(4)}", email: "user_no_co_#{SecureRandom.hex(4)}@example.com")
+          u.team_member&.destroy
+          u
+        }
+        let(:Authorization) { "Bearer #{generate_jwt_token_for_user(user_no_company_for_doc)}" }
+
+        # This RSpec example covers user not associated with company
+        # Note: This `it` block is outside Rswag's `run_test!` for this response,
+        # but Rswag needs a `let` for Authorization to generate its sample.
+        # The actual test logic is below in the RSpec context.
+      end
+    end
+  end
+
+  # --- Swagger Docs for GET /api/v1/companies/:id ---
+  path '/companies/{id}' do # Removed /api/v1 prefix
+    get 'Retrieves a specific company by ID' do
+      tags 'Companies'
+      produces 'application/json'
+      parameter name: :id, in: :path, type: :integer, description: 'ID of the company', required: true
+
+      response '200', 'Company details retrieved' do
+        schema type: :object,
+               properties: {
+                 status: { '$ref' => '#/components/schemas/StatusSuccess' },
+                 company: {
+                   type: :object,
+                   properties: {
+                     id: { type: :integer, example: 1 },
+                     name: { type: :string, example: 'Acme Corp' }
+                   },
+                   required: ['id', 'name']
+                 }
+               },
+               required: ['status', 'company']
+
+        let(:id) { company.id }
+        run_test! do |response| # RSpec assertions within run_test!
+          json_response = JSON.parse(response.body)
+          expect(json_response['status']['code']).to eq(200)
+          expect(json_response['company']['id']).to eq(company.id)
+          expect(json_response['company']['name']).to eq(company.name)
+          expect(json_response['company'].keys).to contain_exactly('id', 'name')
+        end
+      end
+
+      response '404', 'Company not found' do
+        schema type: :object,
+               properties: {
+                 status: { '$ref' => '#/components/schemas/StatusError' },
+                 errors: { type: :array, items: { type: :string }, example: ["Company not found."] }
+               },
+               required: ['status', 'errors']
+        let(:id) { company.id + 9999 } # Non-existent ID
+        run_test! do |response|
+            json_response = JSON.parse(response.body)
+            expect(json_response['status']['code']).to eq(422) # As per controller
+            expect(json_response['errors']).to include('Company not found.')
+        end
+      end
+    end
+  end
+
+  # --- Existing RSpec test examples ---
+  # These will run independently of Rswag's `run_test!` unless `run_test!` is placed
+  # inside each `it` block or structured to replace them.
+  # For this integration, `run_test!` is used for the "happy path" Swagger examples.
+  # The other RSpec examples provide more detailed context-specific tests.
+
+  describe 'GET /api/v1/me/company_social_status (RSpec examples)' do
+    context 'when authenticated' do
+      context 'and user is associated with a company' do
+        # Case: complete Twitter credentials (covered by Rswag response '200' run_test!)
+        # We can add more specific assertions here if needed, beyond what run_test! does by default.
+        context 'and company has complete Twitter credentials' do
+          let!(:twitter_credentials) { create(:credentials_twitter, company: company, api_key: 'key', api_key_secret: 'secret', access_token: 'token', access_token_secret: 'token_secret') }
+          it 'returns status 200 and has_credentials: true' do
+            get '/api/v1/me/company_social_status', headers: { 'Authorization' => "Bearer #{generate_jwt_token_for_user(user)}" }
+            expect(response).to have_http_status(:ok)
+            json_response = JSON.parse(response.body)
+            expect(json_response['status']['code']).to eq(200)
+            expect(json_response['social_networks']['twitter']['has_credentials']).to be_truthy
+          end
+        end
+
+        context 'and company has incomplete Twitter credentials' do
+          let!(:twitter_credentials) { create(:credentials_twitter, company: company, api_key: 'key', api_key_secret: nil) }
+          it 'returns status 200 and has_credentials: false' do
+            get '/api/v1/me/company_social_status', headers: { 'Authorization' => "Bearer #{generate_jwt_token_for_user(user)}" }
+            expect(response).to have_http_status(:ok)
+            json_response = JSON.parse(response.body)
+            expect(json_response['status']['code']).to eq(200)
+            expect(json_response['social_networks']['twitter']['has_credentials']).to be_falsey
+          end
+        end
+
+        context 'and company has no Twitter credentials record' do
+          it 'returns status 200 and has_credentials: false' do
+            get '/api/v1/me/company_social_status', headers: { 'Authorization' => "Bearer #{generate_jwt_token_for_user(user)}" }
+            expect(response).to have_http_status(:ok)
+            json_response = JSON.parse(response.body)
+            expect(json_response['status']['code']).to eq(200)
+            expect(json_response['social_networks']['twitter']['has_credentials']).to be_falsey
+          end
+        end
+      end
+
+      context 'and user is not associated with a company' do
+        let(:user_no_company) { create(:user, username: "user_no_company_#{SecureRandom.hex(4)}", email: "user_no_company_#{SecureRandom.hex(4)}@example.com") }
+        before { user_no_company.team_member&.destroy }
+        it 'returns status 404 (not_found) as per controller logic (actually 422)' do
+          get '/api/v1/me/company_social_status', headers: { 'Authorization' => "Bearer #{generate_jwt_token_for_user(user_no_company)}" }
+          expect(response).to have_http_status(:not_found) # Controller renders :not_found
+          json_response = JSON.parse(response.body)
+          # The controller's error_response uses code 422 by default in its structure.
+          # The HTTP status code is :not_found (404). The internal JSON code is a separate matter.
+          expect(json_response['status']['code']).to eq(422)
+          expect(json_response['errors']).to include('User is not associated with a company.')
+        end
+      end
+    end
+
+    context 'when not authenticated' do
+      it 'returns status 401 (unauthorized)' do
+        get '/api/v1/me/company_social_status'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/companies/:id (RSpec examples)' do
+    # Case: company exists (covered by Rswag response '200' run_test!)
+    # Additional specific assertions can go here if needed.
+    context 'when company exists' do
+        it 'returns status 200 and the company data' do
+          get "/api/v1/companies/#{company.id}"
+          expect(response).to have_http_status(:ok)
+          # assertions are in the run_test! block for the swagger definition
+        end
+      end
+
+    # Case: company does not exist (covered by Rswag response '404' run_test!)
+    context 'when company does not exist' do
+        it 'returns status 404 (not_found) as per controller logic (actually 422 in json)' do
+          get "/api/v1/companies/#{company.id + 999}"
+          expect(response).to have_http_status(:not_found) # Controller renders :not_found
+          # assertions are in the run_test! block for the swagger definition
+        end
+      end
+  end
+end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -1,0 +1,33 @@
+require 'jwt'
+
+module ApiHelpers
+  def generate_jwt_token_for_user(user)
+    payload = {
+      sub: user.id,
+      scp: 'user', # Scope, ensure this matches your Devise setup if applicable
+      aud: nil,    # Audience, ensure this matches
+      iat: Time.now.to_i,
+      exp: (Time.now + 1.hour).to_i, # Token expiration time
+      jti: SecureRandom.uuid
+    }
+    # Ensure Rails.application.credentials.devise_jwt_secret_key! is valid and loaded
+    # For test environment, you might need to ensure credentials are set if not using Figaro/ENV vars
+    # For example, directly access if Rails credentials are set up for test:
+    secret_key = Rails.application.credentials.devise_jwt_secret_key
+    unless secret_key
+      # Fallback for environments where Rails credentials might not be fully loaded in tests
+      # or if you are using a different way to store this specific key for tests.
+      # This is a common pattern if ENV vars are used in config/initializers/devise.rb
+      secret_key = ENV['DEVISE_JWT_SECRET_KEY']
+      if secret_key.blank? && Rails.env.test?
+        # Provide a default dummy key for tests if none is found, but log a warning.
+        # This ensures tests can run but highlights a potential configuration gap.
+        Rails.logger.warn "DEVISE_JWT_SECRET_KEY not found in Rails credentials or ENV for test. Using a default dummy key. Ensure this is configured for real authentication."
+        secret_key = 'dummy_test_secret_key_min_32_chars_long_for_hs256'
+      elsif secret_key.blank?
+        raise "DEVISE_JWT_SECRET_KEY is missing. Cannot generate JWT."
+      end
+    end
+    JWT.encode(payload, secret_key, 'HS256')
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -35,11 +35,59 @@ RSpec.configure do |config|
       ],
       basePath: '/api/v1',
       components: {
+        # Removed the first, now duplicate, securitySchemes definition.
         securitySchemes: {
-          bearer_auth: {
+          Bearer: {
             type: :http,
             scheme: :bearer,
-            bearerFormat: 'JWT' # o el formato adecuado para tu token
+            bearerFormat: 'JWT'
+          }
+        },
+        schemas: {
+          StatusSuccess: { # Defines the structure of the 'status' object itself
+            type: :object,
+            properties: {
+              code: { type: :integer, example: 200 },
+              message: { type: :string, example: "Success" }
+            },
+            required: ['code', 'message']
+          },
+          StatusUnauthorized: { # Defines the structure of the 'status' object for unauthorized
+            type: :object,
+            properties: {
+              code: { type: :integer, example: 401 },
+              message: { type: :string, example: "Unauthorized" }
+            },
+            required: ['code', 'message']
+            # Note: The main response schema using this might add an 'errors' array separately
+            # if the controller for 401 sometimes returns errors (e.g. Devise does for failed login attempts)
+            # For a simple "token missing/invalid" 401, often no error body beyond status.
+          },
+          StatusNotFound: { # Defines the structure for a 'status' object for not found
+            type: :object,
+            properties: {
+              code: { type: :integer, example: 404 }, # Standard HTTP Not Found
+              message: { type: :string, example: "Resource not found" }
+            },
+            required: ['code', 'message']
+            # The main response schema using this will add the 'errors' array:
+            # properties: {
+            #   status: { '$ref': '#/components/schemas/StatusNotFound' },
+            #   errors: { type: :array, items: { type: :string }, example: ["Resource not found."] }
+            # }
+          },
+          StatusError: { # Defines the structure for a generic 'status' object for errors (e.g. 422)
+            type: :object,
+            properties: {
+              code: { type: :integer, example: 422 }, # Example: Unprocessable Entity
+              message: { type: :string, example: "Error" } # Or specific error message
+            },
+            required: ['code', 'message']
+            # The main response schema using this will add the 'errors' array:
+            # properties: {
+            #   status: { '$ref': '#/components/schemas/StatusError' },
+            #   errors: { type: :array, items: { type: :string }, example: ["Validation failed: Details..."] }
+            # }
           }
         }
       }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -5,6 +5,156 @@
     "version": "v1"
   },
   "paths": {
+    "/me/company_social_status": {
+      "get": {
+        "summary": "Retrieves social network credential status for the current user's company",
+        "tags": [
+          "Companies",
+          "User Profile"
+        ],
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Social network status retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "$ref": "#/components/schemas/StatusSuccess"
+                    },
+                    "social_networks": {
+                      "type": "object",
+                      "properties": {
+                        "twitter": {
+                          "type": "object",
+                          "properties": {
+                            "has_credentials": {
+                              "type": "boolean",
+                              "example": true
+                            }
+                          },
+                          "required": [
+                            "has_credentials"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "twitter"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "social_networks"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusUnauthorized"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/companies/{id}": {
+      "get": {
+        "summary": "Retrieves a specific company by ID",
+        "tags": [
+          "Companies"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of the company",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Company details retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "$ref": "#/components/schemas/StatusSuccess"
+                    },
+                    "company": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Acme Corp"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "company"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Company not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "$ref": "#/components/schemas/StatusError"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "Company not found."
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "errors"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/posts": {
       "get": {
         "summary": "Retrieves all posts",
@@ -772,10 +922,80 @@
   "basePath": "/api/v1",
   "components": {
     "securitySchemes": {
-      "bearer_auth": {
+      "Bearer": {
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "StatusSuccess": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "example": 200
+          },
+          "message": {
+            "type": "string",
+            "example": "Success"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      },
+      "StatusUnauthorized": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "example": 401
+          },
+          "message": {
+            "type": "string",
+            "example": "Unauthorized"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      },
+      "StatusNotFound": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "example": 404
+          },
+          "message": {
+            "type": "string",
+            "example": "Resource not found"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      },
+      "StatusError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "example": 422
+          },
+          "message": {
+            "type": "string",
+            "example": "Error"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
       }
     }
   }

--- a/test/models/credentials/twitter_test.rb
+++ b/test/models/credentials/twitter_test.rb
@@ -71,24 +71,61 @@ class Credentials::TwitterTest < ActiveSupport::TestCase
     assert_equal access_token_secret_plain, credentials.access_token_secret
   end
 
-  test "should populate default values from ENV" do
-    env_api_key = "env_api_key"
-    env_api_key_secret = "env_api_key_secret"
-    env_access_token = "env_access_token"
-    env_access_token_secret = "env_access_token_secret"
-
+  test "should NOT populate default values from ENV and attributes should be nil" do
     with_env_values(
-      "TWITTER_API_KEY" => env_api_key,
-      "TWITTER_API_KEY_SECRET" => env_api_key_secret,
-      "TWITTER_ACCESS_TOKEN" => env_access_token,
-      "TWITTER_ACCESS_TOKEN_SECRET" => env_access_token_secret
+      "TWITTER_API_KEY" => "env_api_key",
+      "TWITTER_API_KEY_SECRET" => "env_api_key_secret",
+      "TWITTER_ACCESS_TOKEN" => "env_access_token",
+      "TWITTER_ACCESS_TOKEN_SECRET" => "env_access_token_secret"
     ) do
-      credentials = Credentials::Twitter.new(company: @company)
-      assert_equal env_api_key, credentials.api_key
-      assert_equal env_api_key_secret, credentials.api_key_secret
-      assert_equal env_access_token, credentials.access_token
-      assert_equal env_access_token_secret, credentials.access_token_secret
+      credentials = Credentials::Twitter.new(company: @company) # No params other than company
+      assert_nil credentials.api_key
+      assert_nil credentials.api_key_secret
+      assert_nil credentials.access_token
+      assert_nil credentials.access_token_secret
     end
+  end
+
+  test "#has_credentials? should return true if all keys and tokens are present" do
+    credentials = Credentials::Twitter.new(
+      api_key: "key", api_key_secret: "secret", access_token: "token", access_token_secret: "secret", company: @company
+    )
+    assert credentials.has_credentials?
+  end
+
+  test "#has_credentials? should return false if api_key is missing" do
+    credentials = Credentials::Twitter.new(
+      api_key_secret: "secret", access_token: "token", access_token_secret: "secret", company: @company
+    )
+    assert_not credentials.has_credentials?
+  end
+
+  test "#has_credentials? should return false if api_key_secret is missing" do
+    credentials = Credentials::Twitter.new(
+      api_key: "key", access_token: "token", access_token_secret: "secret", company: @company
+    )
+    assert_not credentials.has_credentials?
+  end
+
+  test "#has_credentials? should return false if access_token is missing" do
+    credentials = Credentials::Twitter.new(
+      api_key: "key", api_key_secret: "secret", access_token_secret: "secret", company: @company
+    )
+    assert_not credentials.has_credentials?
+  end
+
+  test "#has_credentials? should return false if access_token_secret is missing" do
+    credentials = Credentials::Twitter.new(
+      api_key: "key", api_key_secret: "secret", access_token: "token", company: @company
+    )
+    assert_not credentials.has_credentials?
+  end
+
+  test "#has_credentials? should return false if all credentials are blank" do
+    credentials = Credentials::Twitter.new(
+      api_key: "", api_key_secret: "", access_token: "", access_token_secret: "", company: @company
+    )
+    assert_not credentials.has_credentials?
   end
 
   test "belongs_to company association" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ begin
 
   if File.exist?(key_path) && File.exist?(content_path)
     master_key = File.read(key_path).strip
-    
+
     config_file = ActiveSupport::EncryptedFile.new(
       content_path: content_path,
       key_path: key_path, # Corrected: use key_path
@@ -22,12 +22,12 @@ begin
     )
     decrypted_credentials_yaml = config_file.read
     credentials = YAML.load(decrypted_credentials_yaml) || {}
-    
+
     ar_encrypt_creds = credentials['active_record_encryption']
 
     if ar_encrypt_creds && ar_encrypt_creds['primary_key']
       puts "Found primary_key. Configuring ActiveRecord::Encryption directly."
-      
+
       # Use values from credentials or generate new ones if missing
       # Ensure keys are in binary format if OpenSSL::Random.random_bytes is used,
       # or hex if that's what your KDF expects.
@@ -35,7 +35,7 @@ begin
       # if they are intended as raw keys.
       # However, ActiveRecord::Encryption.configure usually expects these as hex strings
       # and derives binary keys from them.
-      
+
       primary_h_key = ar_encrypt_creds['primary_key']
       deterministic_h_key = ar_encrypt_creds['deterministic_key'] || OpenSSL::Random.random_bytes(32).unpack1('H*')
       key_derivation_s = ar_encrypt_creds['key_derivation_salt'] || OpenSSL::Random.random_bytes(32).unpack1('H*')


### PR DESCRIPTION
This commit introduces several enhancements:

1.  **Refactored Twitter Publishing Logic:**
    - `Api::V1::PublishSocialNetwork::Twitter::PublishHelper` now uses Twitter credentials stored in the `Credentials::Twitter` model, associated with a `Company`, instead of relying on ENV variables.
    - The `twitter_client` method in the helper now accepts credentials as parameters.
    - The `post` method fetches the company associated with the post, retrieves its Twitter credentials, and uses them to initialize the client. It handles cases where credentials may be missing or incomplete.

2.  **Credentials::Twitter Model Updates:**
    - Removed the `after_initialize` callback that populated API keys from ENV variables. Initialization now relies on explicitly passed attributes.
    - Added an instance method `has_credentials?` to check if all necessary API keys and tokens (api_key, api_key_secret, access_token, access_token_secret) are present.

3.  **New Company API Endpoints (Api::V1::CompaniesController):**
    - `GET /api/v1/me/company_social_status`: - Authenticated via JWT. - Returns the Twitter credential status for the current user's associated company, in the format: `{ social_networks: { twitter: { has_credentials: true|false } } }`
    - `GET /api/v1/companies/:id`:
        - Public endpoint.
        - Returns basic details (ID, name) of the specified company.

4.  **Testing:**
    - Updated Minitest model tests for `Credentials::Twitter` to reflect model changes (no ENV defaults, `has_credentials?` method).
    - Updated RSpec job tests for `PublishSocialNetworkPostJob` to align with the refactored `PublishHelper` and test various credential scenarios.
    - Added new RSpec request specs for `Api::V1::CompaniesController` covering both new endpoints, authentication, and response structures.
    - All new and modified tests related to these features pass.

5.  **Swagger Documentation:**
    - Added Rswag definitions for the new company API endpoints.
    - Defined shared response schemas in `swagger_helper.rb` for consistency.
    - Regenerated `swagger/swagger.json`.

6.  **User Feedback Incorporated:**
    - Removed unnecessary `.html.erb` view files that were scaffolded for the `Api::V1::CompaniesController`.
    - Reverted argument handling in `PublishSocialNetworkPostJob` (and its tests) to use `args['post_id']` as originally designed in the project, instead of a direct string argument.